### PR TITLE
Upgrade to support Anki 2.1

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from . import nhk_pronunciation

--- a/config.json
+++ b/config.json
@@ -1,0 +1,11 @@
+{
+	"styles": {"class=\"overline\"": "style=\"text-decoration:overline;\"",
+			   "class=\"nopron\"": "style=\"color: royalblue;\"",
+			   "class=\"nasal\"": "style=\"color: red;\"",
+			   "&#42780;": "&#42780;"},
+	"noteTypes": ["japanese", "kanji"],
+	"srcFields": ["Expression", "Kanji Word"],
+	"dstFields": ["Pronunciation"],
+	"regenerateReadings": false,
+	"pronunciationHiragana": false
+}

--- a/config.md
+++ b/config.md
@@ -1,0 +1,14 @@
+*Anki needs to be restarted for changes to applied*
+
+*noteTypes*: By default, the add-on considers a note type Japanese if it finds
+the text "japanese" or "kanji" in the note type name. Case is ignored.
+
+*srcFields*: Fields to generate the reading for.
+
+*dstFields*: Fields where the reading should be placed.
+
+*regenerateReadings*: If a card is shown, should readings for the card be regenerated if the dstField is already filled? Note that these regenerated readings are *not stored, only shown*.
+
+*pronunciationHiragana*: Use hiragana instead of katakana for the readings.
+
+*styles*: Style mappings. Edit this if you want different colors, etc.


### PR DESCRIPTION
The user config section in the Python file has been moved to a config.json
file, such that it can be edited from the Anki user interface (and such
that it persists over upgrades).

The default shortcut Ctrl+6 to add pronunciation has been removed, as it
typically conflicts with other shortcuts.

The dependency on the Japanese add-on was also removed, although it is
not yet known what effect this has. For example, "onLookupPronunciation"
used to call the initLookup() method of the Japanese add-on, but it seems
to work fine without.