### PR TITLE
Do not check on note type by default

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
 			   "class=\"nopron\"": "style=\"color: royalblue;\"",
 			   "class=\"nasal\"": "style=\"color: red;\"",
 			   "&#42780;": "&#42780;"},
-	"noteTypes": ["japanese", "kanji"],
+	"noteTypes": [],
 	"srcFields": ["Expression", "Kanji Word"],
 	"dstFields": ["Pronunciation"],
 	"regenerateReadings": false,

--- a/nhk_pronunciation.py
+++ b/nhk_pronunciation.py
@@ -284,7 +284,8 @@ def add_pronunciation_once(fields, model, data, n):
     """ When possible, temporarily set the pronunciation to a field """
 
     # Check if this is a supported note type. If it is not, return.
-    if not any(nt.lower() in model['name'].lower() for nt in config["noteTypes"]):
+    # If no note type has been specified, we always continue the lookup proces.
+    if config["noteTypes"] and not any(nt.lower() in model['name'].lower() for nt in config["noteTypes"]):
         return fields
 
     src, srcIdx, dst, dstIdx = get_src_dst_fields(fields)
@@ -301,7 +302,8 @@ def add_pronunciation_once(fields, model, data, n):
 
 def add_pronunciation_focusLost(flag, n, fidx):
     # Check if this is a supported note type. If it is not, return.
-    if not any(nt.lower() in n.model()['name'].lower() for nt in config["noteTypes"]):
+    # If no note type has been specified, we always continue the lookup proces.
+    if config["noteTypes"] and not any(nt.lower() in n.model()['name'].lower() for nt in config["noteTypes"]):
         return flag
 
     from aqt import mw
@@ -341,7 +343,8 @@ def regeneratePronunciations(nids):
         note = mw.col.getNote(nid)
 
         # Check if this is a supported note type. If it is not, skip.
-        if not any(nt.lower() in note.model()['name'].lower() for nt in config["noteTypes"]):
+        # If no note type has been specified, we always continue the lookup proces.
+        if config["noteTypes"] and not any(nt.lower() in note.model()['name'].lower() for nt in config["noteTypes"]):
             continue
 
         src, srcIdx, dst, dstIdx = get_src_dst_fields(note)


### PR DESCRIPTION
A user was required to specify (part of) the note type to enable the
lookup of pronunciations.

This commit changes this behavior in the following way:
1. If no note type is specified, a lookup will always be performed.
2. By default, no note types are specified anymore. This means that
   lookups will always be performed by default, if the source and
   destination fields exist.