### PR TITLE
HTML cleanup and subexpression lookup

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,5 +7,6 @@
 	"srcFields": ["Expression", "Kanji Word"],
 	"dstFields": ["Pronunciation"],
 	"regenerateReadings": false,
-	"pronunciationHiragana": false
+	"pronunciationHiragana": false,
+	"useMecab": true
 }

--- a/config.md
+++ b/config.md
@@ -12,3 +12,5 @@ the text "japanese" or "kanji" in the note type name. Case is ignored.
 *pronunciationHiragana*: Use hiragana instead of katakana for the readings.
 
 *styles*: Style mappings. Edit this if you want different colors, etc.
+
+*useMecab*: Whether or not to try and use Mecab to split a sentence/conjugation when performing lookups. The Japanese add-on is required for this to work.


### PR DESCRIPTION
I liked newlines for different subexpressions, otherwise users might have a hard time figuring out what pronunciation goes with what expression. I did it like this for the cards:
![image](https://user-images.githubusercontent.com/3198903/49341214-9acdee00-f64a-11e8-9ca2-63f4aea77b93.png)

And like this for the manual lookup:
![image](https://user-images.githubusercontent.com/3198903/49341200-77a33e80-f64a-11e8-9573-f24a9f079a06.png)

Of course, if people like different separators, we can always add that as a customization option to the config file later. For now I think sane defaults should be good enough.