### PR TITLE
Fix running without Japanese add-on

### DIFF
--- a/nhk_pronunciation.py
+++ b/nhk_pronunciation.py
@@ -254,6 +254,7 @@ def createMenu():
         ml = QMenu()
         ml.setTitle("Lookup")
         mw.form.menuTools.addAction(ml.menuAction())
+        mw.form.menuLookup = ml
 
     ml = mw.form.menuLookup
     # add action


### PR DESCRIPTION
Even though we no longer rely on the Japanese add-on being present at all
times, we would get an exception when it was not installed due to the
submenu not being present.